### PR TITLE
Fix for NPE that would happen when the app was opened, and then clear…

### DIFF
--- a/MaterialThemesMadeEasy/app/src/main/java/com/stevenbyle/android/materialthemes/controller/home/HomeActivity.java
+++ b/MaterialThemesMadeEasy/app/src/main/java/com/stevenbyle/android/materialthemes/controller/home/HomeActivity.java
@@ -60,12 +60,16 @@ public class HomeActivity extends AppCompatActivity implements OnClickListener {
 
         // If no parameters were passed in, default them
         if (args == null) {
-            // Default the theme
-            mCurrentTheme = MaterialTheme.THEME_TEAL;
+            mCurrentTheme = null;
         }
         // Otherwise, set incoming parameters
         else {
             mCurrentTheme = (MaterialTheme) args.getSerializable(KEY_ARG_CURRENT_THEME);
+        }
+
+        // If not set, default the theme
+        if (mCurrentTheme == null) {
+            mCurrentTheme = MaterialTheme.THEME_TEAL;
         }
 
         // Theme must be set before calling super or setContentView


### PR DESCRIPTION
…ed from memory, subsequent loads would send a bundle of args to HomeActivity that the OS attached, which was an unexpected situation as HomeActivity assumed non null args would always have a theme. Added a simple check that would default the current set theme if it is null before trying to use it.

@jhunchar please verify.